### PR TITLE
feat: add --no-build option for simplified Bun/Vite-only workflow

### DIFF
--- a/.github/workflows/test-cli-options.yml
+++ b/.github/workflows/test-cli-options.yml
@@ -669,9 +669,7 @@ jobs:
           cmd="$cmd --linter ${{ matrix.linter }}"
 
           # Default to no-build unless explicitly disabled
-          if [ "${{ matrix.noBuild }}" = "false" ]; then
-            cmd="$cmd --build"
-          else
+          if [ "${{ matrix.noBuild }}" != "false" ]; then
             cmd="$cmd --no-build"
           fi
 

--- a/.github/workflows/test-cli-options.yml
+++ b/.github/workflows/test-cli-options.yml
@@ -652,6 +652,8 @@ jobs:
           echo "Linter: ${{ matrix.linter }}"
 
           # Build the command with conditional flags
+          no_build_value="${{ matrix.noBuild || 'true' }}"
+
           cmd="./dist/index.js test-project-${{ matrix.template }}-${{ matrix.rpc }}-${{ matrix.tanstackQuery }}-${{ matrix.router }}-${{ matrix.linter }} --yes --template ${{ matrix.template }}"
 
           if [ "${{ matrix.rpc }}" = "true" ]; then
@@ -669,7 +671,7 @@ jobs:
           cmd="$cmd --linter ${{ matrix.linter }}"
 
           # Default to no-build unless explicitly disabled
-          if [ "${{ matrix.noBuild }}" != "false" ]; then
+          if [ "$no_build_value" != "false" ]; then
             cmd="$cmd --no-build"
           fi
 
@@ -696,7 +698,9 @@ jobs:
             exit 1
           fi
 
-          if [ "${{ matrix.noBuild }}" = "false" ]; then
+          no_build_value="${{ matrix.noBuild || 'true' }}"
+
+          if [ "$no_build_value" = "false" ]; then
             # Check that server/shared dist directories exist
             if [ ! -d "server/dist" ]; then
               echo "❌ Server build failed - dist directory not found"
@@ -728,7 +732,7 @@ jobs:
               exit 1
             fi
 
-            if [ "${{ matrix.noBuild }}" = "false" ]; then
+            if [ "$no_build_value" = "false" ]; then
               # Verify server build (separate from React Router MPA)
               if [ ! -f "server/dist/index.js" ]; then
                 echo "❌ Server build incomplete - index.js not found"
@@ -744,7 +748,7 @@ jobs:
               exit 1
             fi
 
-            if [ "${{ matrix.noBuild }}" = "false" ]; then
+            if [ "$no_build_value" = "false" ]; then
               if [ ! -f "server/dist/index.js" ]; then
                 echo "❌ Server build incomplete - index.js not found"
                 exit 1

--- a/.github/workflows/test-cli-options.yml
+++ b/.github/workflows/test-cli-options.yml
@@ -517,6 +517,15 @@ jobs:
             linter: "biome"
             test_name: "Default + No RPC + TanStack Query + TanStack Router + Biome"
 
+          # No-build=false coverage
+          - template: "default"
+            rpc: true
+            tanstackQuery: false
+            router: "none"
+            linter: "eslint"
+            noBuild: false
+            test_name: "Default + RPC + No TanStack Query + No Router + ESLint + Build"
+
           # Tailwind template combinations
           - template: "tailwind"
             rpc: true
@@ -659,6 +668,13 @@ jobs:
 
           cmd="$cmd --linter ${{ matrix.linter }}"
 
+          # Default to no-build unless explicitly disabled
+          if [ "${{ matrix.noBuild }}" = "false" ]; then
+            cmd="$cmd --build"
+          else
+            cmd="$cmd --no-build"
+          fi
+
           echo "Running: $cmd"
           eval $cmd
 
@@ -676,15 +692,34 @@ jobs:
         run: |
           cd test-project-${{ matrix.template }}-${{ matrix.rpc }}-${{ matrix.tanstackQuery }}-${{ matrix.router }}-${{ matrix.linter }}
 
-          # Check that dist directories exist
+          # Check client dist directory exists
           if [ ! -d "client/dist" ]; then
             echo "❌ Client build failed - dist directory not found"
             exit 1
           fi
 
-          if [ ! -d "server/dist" ]; then
-            echo "❌ Server build failed - dist directory not found"
-            exit 1
+          if [ "${{ matrix.noBuild }}" = "false" ]; then
+            # Check that server/shared dist directories exist
+            if [ ! -d "server/dist" ]; then
+              echo "❌ Server build failed - dist directory not found"
+              exit 1
+            fi
+
+            if [ ! -d "shared/dist" ]; then
+              echo "❌ Shared build failed - dist directory not found"
+              exit 1
+            fi
+          else
+            # Ensure no-build outputs are not generated
+            if [ -d "server/dist" ]; then
+              echo "❌ Server dist should not exist in no-build mode"
+              exit 1
+            fi
+
+            if [ -d "shared/dist" ]; then
+              echo "❌ Shared dist should not exist in no-build mode"
+              exit 1
+            fi
           fi
 
           # Check for expected files based on router type
@@ -695,10 +730,12 @@ jobs:
               exit 1
             fi
 
-            # Verify server build (separate from React Router MPA)
-            if [ ! -f "server/dist/index.js" ]; then
-              echo "❌ Server build incomplete - index.js not found"
-              exit 1
+            if [ "${{ matrix.noBuild }}" = "false" ]; then
+              # Verify server build (separate from React Router MPA)
+              if [ ! -f "server/dist/index.js" ]; then
+                echo "❌ Server build incomplete - index.js not found"
+                exit 1
+              fi
             fi
 
             echo "✅ React Router MPA build verification passed for ${{ matrix.test_name }}"
@@ -709,9 +746,11 @@ jobs:
               exit 1
             fi
 
-            if [ ! -f "server/dist/index.js" ]; then
-              echo "❌ Server build incomplete - index.js not found"
-              exit 1
+            if [ "${{ matrix.noBuild }}" = "false" ]; then
+              if [ ! -f "server/dist/index.js" ]; then
+                echo "❌ Server build incomplete - index.js not found"
+                exit 1
+              fi
             fi
 
             echo "✅ Build verification passed for ${{ matrix.test_name }}"

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,10 @@ program
 		"specify a client router (none, reactrouter, reactroutermpa, tanstackrouter)",
 	)
 	.option("--linter <linter>", "specify the linter to use (eslint or biome)")
+	.option(
+		"--no-build",
+		"skip tsc compilation, import directly from source (simpler but not packageable)",
+	)
 	.action(create);
 
 program.parse();

--- a/src/installers/no-build.ts
+++ b/src/installers/no-build.ts
@@ -68,6 +68,12 @@ export async function noBuildInstaller(
 			await fs.writeJson(sharedPkgPath, sharedPkg, { spaces: 2 });
 		}
 
+		// Remove prebuilt shared dist if present
+		const sharedDistPath = path.join(projectPath, "shared", "dist");
+		if (await fs.pathExists(sharedDistPath)) {
+			await fs.remove(sharedDistPath);
+		}
+
 		// 3. Update server package.json - replace build with typecheck
 		const serverPkgPath = path.join(projectPath, "server", "package.json");
 		if (await fs.pathExists(serverPkgPath)) {
@@ -80,6 +86,12 @@ export async function noBuildInstaller(
 			serverPkg.scripts.typecheck = "tsc --noEmit";
 
 			await fs.writeJson(serverPkgPath, serverPkg, { spaces: 2 });
+		}
+
+		// Remove prebuilt server dist if present
+		const serverDistPath = path.join(projectPath, "server", "dist");
+		if (await fs.pathExists(serverDistPath)) {
+			await fs.remove(serverDistPath);
 		}
 
 		// 4. Update client package.json - remove tsc -b from build, add typecheck

--- a/src/installers/no-build.ts
+++ b/src/installers/no-build.ts
@@ -1,0 +1,114 @@
+import path from "node:path";
+import { consola } from "consola";
+import fs from "fs-extra";
+import pc from "picocolors";
+import yoctoSpinner from "yocto-spinner";
+import type { ProjectOptions } from "@/types";
+
+export async function noBuildInstaller(
+	options: Required<ProjectOptions>,
+): Promise<boolean> {
+	const spinner = yoctoSpinner({
+		text: "Configuring no-build mode (direct source imports)...",
+	}).start();
+
+	try {
+		const { projectName } = options;
+		const projectPath = path.resolve(process.cwd(), projectName);
+
+		// 1. Update root package.json - remove postinstall build script
+		const rootPkgPath = path.join(projectPath, "package.json");
+		if (await fs.pathExists(rootPkgPath)) {
+			const rootPkg = await fs.readJson(rootPkgPath);
+
+			if (rootPkg.scripts?.postinstall) {
+				delete rootPkg.scripts.postinstall;
+			}
+
+			await fs.writeJson(rootPkgPath, rootPkg, { spaces: 2 });
+		}
+
+		// 2. Update shared package.json - exports point to src, remove build/watch, add typecheck
+		const sharedPkgPath = path.join(projectPath, "shared", "package.json");
+		if (await fs.pathExists(sharedPkgPath)) {
+			const sharedPkg = await fs.readJson(sharedPkgPath);
+
+			// Update main/exports to point to src instead of dist
+			if (sharedPkg.main) {
+				sharedPkg.main = sharedPkg.main.replace(/^\.\/dist\//, "./src/");
+				sharedPkg.main = sharedPkg.main.replace(/\.js$/, ".ts");
+			}
+			if (sharedPkg.types) {
+				sharedPkg.types = sharedPkg.types.replace(/^\.\/dist\//, "./src/");
+				sharedPkg.types = sharedPkg.types.replace(/\.d\.ts$/, ".ts");
+			}
+			if (sharedPkg.exports) {
+				for (const key of Object.keys(sharedPkg.exports)) {
+					const exp = sharedPkg.exports[key];
+					if (typeof exp === "string") {
+						sharedPkg.exports[key] = exp
+							.replace(/^\.\/dist\//, "./src/")
+							.replace(/\.js$/, ".ts");
+					} else if (typeof exp === "object" && exp !== null) {
+						sharedPkg.exports[key] = "./src/index.ts";
+					}
+				}
+			}
+
+			// Remove build and dev/watch scripts, add typecheck
+			if (sharedPkg.scripts?.build) {
+				delete sharedPkg.scripts.build;
+			}
+			if (sharedPkg.scripts?.dev) {
+				delete sharedPkg.scripts.dev;
+			}
+			sharedPkg.scripts = sharedPkg.scripts || {};
+			sharedPkg.scripts.typecheck = "tsc --noEmit";
+
+			await fs.writeJson(sharedPkgPath, sharedPkg, { spaces: 2 });
+		}
+
+		// 3. Update server package.json - replace build with typecheck
+		const serverPkgPath = path.join(projectPath, "server", "package.json");
+		if (await fs.pathExists(serverPkgPath)) {
+			const serverPkg = await fs.readJson(serverPkgPath);
+
+			// Remove build script, add typecheck
+			if (serverPkg.scripts?.build) {
+				delete serverPkg.scripts.build;
+			}
+			serverPkg.scripts.typecheck = "tsc --noEmit";
+
+			await fs.writeJson(serverPkgPath, serverPkg, { spaces: 2 });
+		}
+
+		// 4. Update client package.json - remove tsc -b from build, add typecheck
+		const clientPkgPath = path.join(projectPath, "client", "package.json");
+		if (await fs.pathExists(clientPkgPath)) {
+			const clientPkg = await fs.readJson(clientPkgPath);
+
+			// Remove tsc -b from build script (vite handles it directly)
+			if (clientPkg.scripts?.build) {
+				clientPkg.scripts.build = clientPkg.scripts.build
+					.replace(/tsc -b\s*&&\s*/g, "")
+					.replace(/\s*&&\s*tsc -b/g, "");
+			}
+
+			// Add typecheck script
+			clientPkg.scripts.typecheck = "tsc --noEmit";
+
+			await fs.writeJson(clientPkgPath, clientPkg, { spaces: 2 });
+		}
+
+		spinner.success("No-build mode configured (direct source imports)");
+		return true;
+	} catch (err: unknown) {
+		spinner.error("Failed to configure no-build mode");
+		if (err instanceof Error) {
+			consola.error(pc.red("Error:"), err.message);
+		} else {
+			consola.error(pc.red("Error: Unknown error"));
+		}
+		return false;
+	}
+}

--- a/src/lib/install-packages.ts
+++ b/src/lib/install-packages.ts
@@ -1,16 +1,17 @@
-import type { ProjectOptions } from "@/types";
-import { setupBiome } from "./setup-biome";
 import path from "node:path";
-import { tanstackQueryInstaller } from "@/installers/tanstack-query";
-import { rpcInstaller } from "@/installers/rpc";
+import { noBuildInstaller } from "@/installers/no-build";
 import { reactRouterInstaller } from "@/installers/react-router";
 import { reactRouterMpaInstaller } from "@/installers/react-router-mpa";
+import { rpcInstaller } from "@/installers/rpc";
+import { tanstackQueryInstaller } from "@/installers/tanstack-query";
 import { tanstackRouterInstaller } from "@/installers/tanstack-router";
+import type { ProjectOptions } from "@/types";
+import { setupBiome } from "./setup-biome";
 
 export async function installPackages(
 	options: Required<ProjectOptions>,
 ): Promise<boolean> {
-	const { projectName, rpc, router, linter, tanstackQuery } = options;
+	const { projectName, rpc, router, linter, tanstackQuery, noBuild } = options;
 
 	const projectPath = path.resolve(process.cwd(), projectName);
 
@@ -41,6 +42,11 @@ export async function installPackages(
 				break;
 			}
 		}
+	}
+
+	// Run noBuild installer last - it rewrites imports in files created by other installers
+	if (noBuild) {
+		await noBuildInstaller(options);
 	}
 
 	return false;

--- a/src/lib/prompt-for-options.ts
+++ b/src/lib/prompt-for-options.ts
@@ -143,6 +143,27 @@ export async function promptForOptions(
 		useTanstackQuery = tanstackQueryResponse;
 	}
 
+	let noBuild = options.noBuild;
+
+	if (!options.yes && options.noBuild === undefined) {
+		const { data: noBuildResponse, error } = await tryCatch(
+			consola.prompt(
+				"Skip TypeScript compilation? (Use Bun/Vite to run TS directly - simpler but not packageable)",
+				{
+					type: "confirm",
+					initial: true,
+				},
+			),
+		);
+
+		if (error) {
+			consola.error("Project creation cancelled.");
+			process.exit(1);
+		}
+
+		noBuild = noBuildResponse;
+	}
+
 	return {
 		...options,
 		projectName,
@@ -153,5 +174,6 @@ export async function promptForOptions(
 		linter,
 		router,
 		tanstackQuery: useTanstackQuery,
+		noBuild: options.yes ? (options.noBuild ?? true) : noBuild,
 	};
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,7 @@ export type ProjectOptions = {
 	linter?: "eslint" | "biome";
 	router?: "none" | "reactrouter" | "reactroutermpa" | "tanstackrouter";
 	tanstackQuery?: boolean;
+	noBuild?: boolean;
 };
 
 export interface ProjectResult {


### PR DESCRIPTION
## Summary

Adds a `--no-build` scaffolding option that skips TypeScript compilation entirely, allowing Bun to run TS files directly and Vite to transpile TS during client builds.

This is ideal for simpler projects (e.g., backend-shared-client monorepos) that don't need packages to be independently buildable/publishable.

## Changes

- Add `noBuild` option to `ProjectOptions` type
- Add `--no-build` CLI flag
- Add interactive prompt (defaults to `true` with `--yes` for quick starts)
- Create `no-build.ts` installer that:
  - Removes `postinstall` build script from root. Not needed since it does not need to build.
  - Updates `shared` package.json: exports point to `./src/`, removes build/dev scripts, adds `typecheck`
  - Updates `server` package.json: removes `build`, adds `typecheck`
  - Updates `client` package.json: removes `tsc -b` from build (Vite handles it), adds `typecheck`
- Modify `rpc.ts` installer to conditionally:
  - Skip `tsc --watch` in dev script
  - Set server exports to `./src/client.ts` instead of `./dist/`

## Behavior Comparison

| Aspect | Standard Mode | No-Build Mode |
|--------|---------------|---------------|
| Server dev | `bun --watch src/index.ts & tsc --watch` | `bun --watch src/index.ts` |
| Server exports | `./dist/client.{d.ts,js}` | `./src/client.ts` |
| Client build | `tsc -b && vite build` | `vite build` |
| Type checking | During build | `bun run typecheck` |

## Testing

I have tested this with few of the bundles. I have used this approach to setup https://github.com/vidos-id/usecase-demos and it was working nicely

## Dependencies

Requires [stevedylandev/create-bhvr#27](https://github.com/stevedylandev/create-bhvr/pull/27) (removes `/dist` from import paths in base template).
